### PR TITLE
Test coverage report

### DIFF
--- a/php/class-rewrite-testing-tests.php
+++ b/php/class-rewrite-testing-tests.php
@@ -14,6 +14,8 @@ if ( ! class_exists( 'Rewrite_Testing_Tests' ) ) :
 
 		protected $extended_rewrite_rules = false;
 
+		protected $tested = array();
+
 		private function __construct() {
 			/* Don't do anything, needs to be initialized via instance() method */
 		}
@@ -37,7 +39,6 @@ if ( ! class_exists( 'Rewrite_Testing_Tests' ) ) :
 		public function basic_test( $request ) {
 			if ( false === $this->basic_rewrite_rules ) {
 				$this->basic_rewrite_rules = $this->get_rules();
-				$this->tested = array();
 				if ( is_wp_error( $this->basic_rewrite_rules ) ) {
 					return $this->basic_rewrite_rules;
 				} elseif ( empty( $this->basic_rewrite_rules ) ) {
@@ -50,7 +51,7 @@ if ( ! class_exists( 'Rewrite_Testing_Tests' ) ) :
 			foreach ( $this->basic_rewrite_rules as $rule => $maybe_target ) {
 				if ( preg_match( "!^$rule!", $request, $matches ) ) {
 					$target = $maybe_target['rewrite'];
-					$this->tested[ $rule ] = $maybe_target;
+					$this->tested[ $rule ] = $maybe_target['rewrite'];
 					break;
 				}
 			}
@@ -62,7 +63,7 @@ if ( ! class_exists( 'Rewrite_Testing_Tests' ) ) :
 			return $this->tested;
 		}
 
-		public function get_basic_rewrite_rules() {
+		public function get_rewrite_rules() {
 			return $this->basic_rewrite_rules;
 		}
 
@@ -112,6 +113,8 @@ if ( ! class_exists( 'Rewrite_Testing_Tests' ) ) :
 			}
 
 			if ( isset( $matched_rule ) ) {
+				$this->tested[ $match ] = $query;
+
 				// Trim the query of everything up to the '?'.
 				$query = preg_replace( '!^.+\?!', '', $query );
 

--- a/php/class-rewrite-testing-tests.php
+++ b/php/class-rewrite-testing-tests.php
@@ -37,6 +37,7 @@ if ( ! class_exists( 'Rewrite_Testing_Tests' ) ) :
 		public function basic_test( $request ) {
 			if ( false === $this->basic_rewrite_rules ) {
 				$this->basic_rewrite_rules = $this->get_rules();
+				$this->tested = array();
 				if ( is_wp_error( $this->basic_rewrite_rules ) ) {
 					return $this->basic_rewrite_rules;
 				} elseif ( empty( $this->basic_rewrite_rules ) ) {
@@ -49,11 +50,20 @@ if ( ! class_exists( 'Rewrite_Testing_Tests' ) ) :
 			foreach ( $this->basic_rewrite_rules as $rule => $maybe_target ) {
 				if ( preg_match( "!^$rule!", $request, $matches ) ) {
 					$target = $maybe_target['rewrite'];
+					$this->tested[ $rule ] = $maybe_target;
 					break;
 				}
 			}
 
 			return array( $rule, $target );
+		}
+
+		public function get_tested() {
+			return $this->tested;
+		}
+
+		public function get_basic_rewrite_rules() {
+			return $this->basic_rewrite_rules;
 		}
 
 		public function extended_test( $request ) {

--- a/rewrite-testing.php
+++ b/rewrite-testing.php
@@ -183,15 +183,15 @@ if ( ! class_exists( 'Rewrite_Testing' ) ) :
 					<div class="message notice notice-info">
 						<p><?php
 							printf(
-								__( '%1$s/%2$s rewrite rules covered (%3$s%%).', 'rewrite-testing' ),
+								esc_html__( '%1$s/%2$s rewrite rules covered (%3$s%%).', 'rewrite-testing' ),
 								number_format_i18n( $summary['tested'] ),
 								number_format_i18n( $summary['total'] ),
 								number_format_i18n( $summary['coverage'] )
 							);
 							if ( ! empty( $summary['missed_rules'] ) ) {
 								printf(
-									__( ' <a href="%1$s">Show untested rules</a>', 'rewrite-testing' ),
-									'#rewrite_testing_untested'
+								    ' <a href="#rewrite_testing_untested">%1$s</a>',
+								    esc_html__( 'Show untested rules', 'rewrite-rules' )
 								);
 							}
 						?></p>


### PR DESCRIPTION
I wanted to know how many of the rewrite rules on my site were covered by rewrite rule tests, so I knocked up this quick and dirty test coverage report which is shown above the test results.

![screenshot 2015-03-31 00 13 27](https://cloud.githubusercontent.com/assets/208434/6910341/730a6d72-d749-11e4-85ca-b127444170bf.png)

I've already found it really handy for quickly seeing what my test coverage is and which rewrite rules I need to write tests for.

Feedback appreciated. If you're interested in merging it in we can get it tidied up.