### PR TITLE
Populate the value of `$wordpress_subdir_for_site` just once

### DIFF
--- a/rewrite-testing.php
+++ b/rewrite-testing.php
@@ -416,6 +416,7 @@ if ( ! class_exists( 'Rewrite_Testing' ) ) :
 			$tests = $this->test_cases();
 			$results = array();
 			$this->errors = 0;
+			$wordpress_subdir_for_site = parse_url( home_url(), PHP_URL_PATH );
 
 			foreach ( $tests as $group => $test_cases ) {
 				foreach ( $test_cases as $path => $test ) {
@@ -435,7 +436,6 @@ if ( ! class_exists( 'Rewrite_Testing' ) ) :
 
 					// Setup our "match path" to run against the regex
 					$match_path = parse_url( esc_url( $path ), PHP_URL_PATH );
-					$wordpress_subdir_for_site = parse_url( home_url(), PHP_URL_PATH );
 					if ( ! empty( $wordpress_subdir_for_site ) ) {
 						$match_path = str_replace( $wordpress_subdir_for_site, '', $match_path );
 					}


### PR DESCRIPTION
Avoids calling `parse_url()` and `home_url()` in each test.