### PR TITLE
WP-CLI commands

### DIFF
--- a/class-wp-cli.php
+++ b/class-wp-cli.php
@@ -1,0 +1,382 @@
+<?php
+
+/**
+ * View and run rewrite rule tests.
+ *
+ */
+class Rewrite_Rule_Test_Command extends WP_CLI_Command {
+
+	protected static $colors = array(
+		'ok'      => '%g',
+		'error'   => '%r',
+		'tested'  => '%g',
+		'missed'  => '%r',
+		'Passing' => '%g',
+		'Failing' => '%r',
+	);
+
+	/**
+	 * List the available rewrite rule tests.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--fields=<fields>]
+	 * : Limit the output to specific fields.
+	 *
+	 * [--groups=<groups>]
+	 * : Limit the output to specific test groups.
+	 *
+	 * [--format=<format>]
+	 * : Accepted values: table, json, csv. Default: table.
+	 *
+	 * ## AVAILABLE FIELDS
+	 *
+	 * These fields will be displayed by default for each test:
+	 * * group
+	 * * path
+	 * * match
+	 * * query
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp rewrite test list
+	 *
+	 *     wp rewrite test list --groups=Categories,Tags
+	 *
+	 *     wp rewrite test list --fields=path,match --format=csv
+	 *
+	 * @subcommand list
+	 */
+	public function list_( $args, $assoc_args ) {
+		$assoc_args = array_merge( array(
+			'groups' => null,
+		), $assoc_args );
+
+		$tests = self::get_tests( $assoc_args );
+
+		if ( is_wp_error( $tests ) ) {
+			WP_CLI::error( $tests );
+		}
+
+		$formatter = $this->get_formatter( $assoc_args, array(
+			'group',
+			'path',
+			'match',
+			'query',
+		) );
+
+		$formatter->display_items( $tests );
+
+	}
+
+	/**
+	 * Get a summary of the rewrite test results.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--format=<format>]
+	 * : Accepted values: table, json, csv. Default: table.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp rewrite test summary
+	 *
+	 *     wp rewrite test summary --format=json
+	 *
+	 */
+	public function summary( $args, $assoc_args ) {
+		$summary = self::get_summary( $assoc_args );
+
+		$formatter = $this->get_formatter( $assoc_args, array(
+			'status',
+			'errors',
+			'tested',
+			'missed',
+			'coverage',
+		) );
+
+		$formatter->display_item( $summary );
+	}
+
+	/**
+	 * Get the status of the rewrite tests.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp rewrite test status
+	 *
+	 */
+	public function status( $args, $assoc_args ) {
+		$summary = self::get_summary( $assoc_args );
+
+		WP_CLI::line( $summary['status'] );
+
+	}
+
+	/**
+	 * Are the rewrite tests passing?
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp rewrite test passing
+	 *
+	 */
+	public function passing( $args, $assoc_args ) {
+		$summary = self::get_summary( $assoc_args );
+
+		if ( $summary['passing'] ) {
+			WP_CLI::success( $summary['status'] );
+		} else {
+			WP_CLI::error( $summary['status'] );
+		}
+	}
+
+	/**
+	 * Run the rewrite tests.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--fields=<fields>]
+	 * : Limit the output to specific fields.
+	 *
+	 * [--format=<format>]
+	 * : Accepted values: table, json, csv. Default: table.
+	 *
+	 * ## AVAILABLE FIELDS
+	 *
+	 * These fields will be displayed by default for each test result:
+	 * * status
+	 * * group
+	 * * path
+	 * * matched
+	 * * rewrite_test
+	 * * rewrite_result
+	 *
+	 * These fields are optionally available:
+	 * * query_test
+	 * * query_result
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp rewrite test run
+	 *
+	 *     wp rewrite test run --fields=status,path,rewrite_test,rewrite_result,query_test,query_result --format=csv
+	 *
+	 */
+	public function run( $args, $assoc_args ) {
+		$results = self::run_tests( $assoc_args );
+
+		if ( is_wp_error( $results ) ) {
+			WP_CLI::error( $results );
+		}
+
+		$formatter = $this->get_formatter( $assoc_args, array(
+			'status',
+			'group',
+			'path',
+			'matched',
+			'rewrite_test',
+			'rewrite_result',
+		) );
+
+		$formatter->display_items( $results );
+
+	}
+
+	/**
+	 * Get a test coverage report for the rewrite rules on the site.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--status=<status>]
+	 * : Limit the output to a specific status. Accepted values: missed, tested. Default: "missed,tested".
+	 *
+	 * [--format=<format>]
+	 * : Accepted values: table, json, csv. Default: table.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp rewrite test coverage
+	 *
+	 *     wp rewrite test coverage --status=missed --format=json
+	 *
+	 */
+	public function coverage( $args, $assoc_args ) {
+		$assoc_args = array_merge( array(
+			'status' => 'missed,tested',
+		), $assoc_args );
+
+		$coverage = self::get_coverage( $assoc_args );
+
+		$formatter = $this->get_formatter( $assoc_args, array(
+			'status',
+			'match',
+			'query',
+			'source',
+		) );
+
+		$formatter->display_items( $coverage );
+	}
+
+	protected static function get_coverage( array $assoc_args ) {
+		$rrt     = Rewrite_Testing::instance();
+		$summary = $rrt->get_summary();
+		$coverage = array();
+
+		if ( ! is_array( $assoc_args['status'] ) ) {
+			$assoc_args['status'] = explode( ',', $assoc_args['status'] );
+		}
+
+		foreach ( $assoc_args['status'] as $status ) {
+			if ( ! isset( $summary[ "{$status}_rules" ] ) ) {
+				continue;
+			}
+			foreach ( $summary[ "{$status}_rules" ] as $rule => $target ) {
+				$coverage[] = array(
+					'status' => self::colorize( $status, self::$colors[ $status ], $assoc_args ),
+					'match'  => $rule,
+					'query'  => $target['rewrite'],
+					'source' => $target['source'],
+				);
+			}
+		}
+
+		return $coverage;
+	}
+
+	protected static function run_tests( $assoc_args ) {
+		$rrt     = Rewrite_Testing::instance();
+		$results = $rrt->test();
+		$list    = array();
+
+		if ( empty( $results ) ) {
+			return new WP_Error( 'no_tests', 'No tests found' );
+		}
+
+		if ( is_wp_error( $results ) ) {
+			return $results;
+		}
+
+		$list = self::process_test_results( $results, $assoc_args );
+
+		return $list;
+
+	}
+
+	protected static function process_test_results( array $results, array $assoc_args ) {
+
+		$list = array();
+
+		foreach ( $results as $result ) {
+			if ( empty( $result['status'] ) ) {
+				$result['status'] = self::colorize( 'ok', self::$colors['ok'], $assoc_args );
+			} else {
+				$result['status'] = self::colorize( $result['status'], self::$colors[ $result['status'] ], $assoc_args );
+			}
+			if ( isset( $result['test']['match'] ) ) {
+				$result['rewrite_test'] = $result['test']['match'];
+			} else {
+				$result['rewrite_test'] = '';
+			}
+			$result['rewrite_result'] = $result['target'];
+			if ( isset( $result['test']['query'] ) ) {
+				$result['query_test'] = $result['test']['query'];
+			} else {
+				$result['query_test'] = '';
+			}
+			$result['query_result'] = $result['query'];
+			$result['matched']      = $result['rule'];
+			$list[] = $result;
+		}
+
+		return $list;
+
+	}
+
+	protected static function get_tests( array $args ) {
+		$rrt   = Rewrite_Testing::instance();
+		$tests = $rrt->test_cases();
+		$list  = array();
+
+		if ( empty( $tests ) ) {
+			return new WP_Error( 'no_tests', 'No tests found' );
+		}
+
+		if ( $args['groups'] ) {
+
+			if ( ! is_array( $args['groups'] ) ) {
+				$args['groups'] = explode( ',', $args['groups'] );
+			}
+
+			$tests = array_intersect_key( $tests, array_flip( $args['groups'] ) );
+
+			if ( empty( $tests ) ) {
+				return new WP_Error( 'no_matching_tests', 'No matching tests found' );
+			}
+
+		}
+
+		foreach ( $tests as $group => $test_cases ) {
+			$list = array_merge( $list, self::process_test_cases( $test_cases, $group ) );
+		}
+
+		return $list;
+	}
+
+	protected static function process_test_cases( array $test_cases, $group ) {
+
+		$list = array();
+
+		foreach ( $test_cases as $path => $test ) {
+			if ( ! is_array( $test ) ) {
+				$test = array(
+					'match' => $test,
+				);
+			}
+			if ( ! isset( $test['query'] ) ) {
+				$test['query'] = null;
+			}
+			if ( ! isset( $test['match'] ) ) {
+				$test['match'] = null;
+			}
+			$test['group'] = $group;
+			$test['path']  = $path;
+			$list[] = $test;
+		}
+
+		return $list;
+
+	}
+
+	protected static function get_summary( $assoc_args ) {
+
+		$rrt     = Rewrite_Testing::instance();
+		$summary = $rrt->get_summary();
+		$list    = array(
+			'status'   => self::colorize( $summary['status'], self::$colors[ $summary['status'] ], $assoc_args ),
+			'passing'  => $summary['passing'],
+			'errors'   => ! empty( $summary['error_count'] ) ? $summary['error_count'] : 0,
+			'total'    => $summary['total'],
+			'tested'   => $summary['tested'],
+			'missed'   => $summary['missed'],
+			'coverage' => sprintf( '%d%%', $summary['coverage'] ),
+		);
+
+		return $list;
+
+	}
+
+	protected static function colorize( $text, $color, $assoc_args ) {
+		if ( ! empty( $assoc_args['format'] ) && ( 'table' !== $assoc_args['format'] ) ) {
+			return $text;
+		}
+		return WP_CLI::colorize( $color . $text . '%n' );
+	}
+
+	private function get_formatter( &$assoc_args, $fields ) {
+		return new \WP_CLI\Formatter( $assoc_args, $fields );
+	}
+
+}
+
+WP_CLI::add_command( 'rewrite test', 'Rewrite_Rule_Test_Command' );

--- a/php/class-rewrite-testing-tests.php
+++ b/php/class-rewrite-testing-tests.php
@@ -14,6 +14,8 @@ if ( ! class_exists( 'Rewrite_Testing_Tests' ) ) :
 
 		protected $extended_rewrite_rules = false;
 
+		protected $tested = array();
+
 		private function __construct() {
 			/* Don't do anything, needs to be initialized via instance() method */
 		}
@@ -37,7 +39,6 @@ if ( ! class_exists( 'Rewrite_Testing_Tests' ) ) :
 		public function basic_test( $request ) {
 			if ( false === $this->basic_rewrite_rules ) {
 				$this->basic_rewrite_rules = $this->get_rules();
-				$this->tested = array();
 				if ( is_wp_error( $this->basic_rewrite_rules ) ) {
 					return $this->basic_rewrite_rules;
 				} elseif ( empty( $this->basic_rewrite_rules ) ) {
@@ -50,7 +51,7 @@ if ( ! class_exists( 'Rewrite_Testing_Tests' ) ) :
 			foreach ( $this->basic_rewrite_rules as $rule => $maybe_target ) {
 				if ( preg_match( "!^$rule!", $request, $matches ) ) {
 					$target = $maybe_target['rewrite'];
-					$this->tested[ $rule ] = $maybe_target;
+					$this->tested[ $rule ] = $maybe_target['rewrite'];
 					break;
 				}
 			}
@@ -62,7 +63,7 @@ if ( ! class_exists( 'Rewrite_Testing_Tests' ) ) :
 			return $this->tested;
 		}
 
-		public function get_basic_rewrite_rules() {
+		public function get_rewrite_rules() {
 			return $this->basic_rewrite_rules;
 		}
 
@@ -112,6 +113,8 @@ if ( ! class_exists( 'Rewrite_Testing_Tests' ) ) :
 			}
 
 			if ( isset( $matched_rule ) ) {
+				$this->tested[ $match ] = $query;
+
 				// Trim the query of everything up to the '?'.
 				$query = preg_replace( '!^.+\?!', '', $query );
 

--- a/php/class-rewrite-testing-tests.php
+++ b/php/class-rewrite-testing-tests.php
@@ -51,7 +51,7 @@ if ( ! class_exists( 'Rewrite_Testing_Tests' ) ) :
 			foreach ( $this->basic_rewrite_rules as $rule => $maybe_target ) {
 				if ( preg_match( "!^$rule!", $request, $matches ) ) {
 					$target = $maybe_target['rewrite'];
-					$this->tested[ $rule ] = $maybe_target['rewrite'];
+					$this->tested[ $rule ] = $maybe_target;
 					break;
 				}
 			}
@@ -113,7 +113,7 @@ if ( ! class_exists( 'Rewrite_Testing_Tests' ) ) :
 			}
 
 			if ( isset( $matched_rule ) ) {
-				$this->tested[ $match ] = $query;
+				$this->tested[ $match ] = $this->basic_rewrite_rules[ $match ];
 
 				// Trim the query of everything up to the '?'.
 				$query = preg_replace( '!^.+\?!', '', $query );

--- a/php/class-rewrite-testing-tests.php
+++ b/php/class-rewrite-testing-tests.php
@@ -37,6 +37,7 @@ if ( ! class_exists( 'Rewrite_Testing_Tests' ) ) :
 		public function basic_test( $request ) {
 			if ( false === $this->basic_rewrite_rules ) {
 				$this->basic_rewrite_rules = $this->get_rules();
+				$this->tested = array();
 				if ( is_wp_error( $this->basic_rewrite_rules ) ) {
 					return $this->basic_rewrite_rules;
 				} elseif ( empty( $this->basic_rewrite_rules ) ) {
@@ -49,11 +50,20 @@ if ( ! class_exists( 'Rewrite_Testing_Tests' ) ) :
 			foreach ( $this->basic_rewrite_rules as $rule => $maybe_target ) {
 				if ( preg_match( "!^$rule!", $request, $matches ) ) {
 					$target = $maybe_target['rewrite'];
+					$this->tested[ $rule ] = $maybe_target;
 					break;
 				}
 			}
 
 			return array( $rule, $target );
+		}
+
+		public function get_tested() {
+			return $this->tested;
+		}
+
+		public function get_basic_rewrite_rules() {
+			return $this->basic_rewrite_rules;
 		}
 
 		public function extended_test( $request ) {

--- a/rewrite-testing.php
+++ b/rewrite-testing.php
@@ -557,9 +557,11 @@ if ( ! class_exists( 'Rewrite_Testing' ) ) :
 
 			if ( $this->errors ) {
 				$this->summary['status'] = __( 'Failing', 'rewrite-testing' );
+				$this->summary['passing'] = false;
 				$this->summary['error_count'] = $this->errors;
 			} else {
 				$this->summary['status'] = __( 'Passing', 'rewrite-testing' );
+				$this->summary['passing'] = true;
 			}
 
 			$this->summary['tested_rules'] = Rewrite_Testing_Tests()->get_tested();
@@ -642,3 +644,7 @@ if ( ! class_exists( 'Rewrite_Testing' ) ) :
 	add_action( 'after_setup_theme', 'Rewrite_Testing' );
 
 endif;
+
+if ( defined( 'WP_CLI' ) && WP_CLI && is_readable( $wp_cli = dirname( __FILE__ ) . '/class-wp-cli.php' ) ) {
+	include_once $wp_cli;
+}


### PR DESCRIPTION
This introduces `wp rewrite test`, with the following subcommands:

 * `wp rewrite test list [--fields=<fields>] [--groups=<groups>] [--format=<format>]`

    List the available rewrite rule tests.

 * `wp rewrite test run [--fields=<fields>] [--format=<format>]`

    Run the rewrite tests.

 * `wp rewrite test summary [--format=<format>]`

    Get a summary of the rewrite test results.

 * `wp rewrite test coverage [--status=<status>] [--format=<format>]`

    Get a test coverage report for the rewrite rules on the site.
        
 * `wp rewrite test passing`

    Are the rewrite tests passing? (Returns a success / error)

 * `wp rewrite test status`

    Get the status of the rewrite tests (Returns as Passing / Failing string)

Two notes:

 * This branches from the `test-coverage` branch.
 * The wonky table layout due to the `%` symbol in the summary command is a [known issue in WP-CLI](https://github.com/wp-cli/wp-cli/issues/1736).

Some screenshots of results:

`wp rewrite test list`
![wp rewrite test list](https://cloud.githubusercontent.com/assets/208434/6948671/37004798-d8a7-11e4-8946-6c593806b491.png)

`wp rewrite test run`
![wp rewrite test run](https://cloud.githubusercontent.com/assets/208434/6948670/36ff0748-d8a7-11e4-95c6-c206adb95eac.png)

`wp rewrite test coverage`
![wp rewrite test coverage](https://cloud.githubusercontent.com/assets/208434/6948668/36fddc06-d8a7-11e4-8cbb-605205b330b3.png)

`wp rewrite test summary`
![wp rewrite test summary](https://cloud.githubusercontent.com/assets/208434/6948669/36fe0bfe-d8a7-11e4-9a5f-3ebcdc8bc1fd.png)